### PR TITLE
added serialisation interface to Params classes

### DIFF
--- a/lib_nn/api/AbstractKernel.hpp
+++ b/lib_nn/api/AbstractKernel.hpp
@@ -1,6 +1,7 @@
 #ifndef LIB_NN_ABSTRACT_KERNEL_HPP_
 #define LIB_NN_ABSTRACT_KERNEL_HPP_
 
+#include "Serialisable.hpp"
 #include "geom/Filter2dGeometry.hpp"
 
 namespace nn {
@@ -18,7 +19,7 @@ class AbstractKernel {
    *
    * @see AbstractKernel
    */
-  class Params {
+  class Params : public Serialisable {
    public:
     /**
      * The first (`h_begin`; inclusive) and final (`h_end`; exclusive) rows of
@@ -68,6 +69,16 @@ class AbstractKernel {
      * to the adjecent pixel to the right.
      */
     int32_t output_w_mem_stride;
+
+    Params()
+        : h_begin(0),
+          h_end(0),
+          w_begin(0),
+          w_end(0),
+          output_channel_group_count(0),
+          output_channel_slice_offset(0),
+          output_h_mem_stride(0),
+          output_w_mem_stride(0) {}
 
     Params(const ImageGeometry &output_image, const ImageRegion &output_region,
            const int channels_per_group)

--- a/lib_nn/api/AbstractKernel.hpp
+++ b/lib_nn/api/AbstractKernel.hpp
@@ -70,16 +70,6 @@ class AbstractKernel {
      */
     int32_t output_w_mem_stride;
 
-    Params()
-        : h_begin(0),
-          h_end(0),
-          w_begin(0),
-          w_end(0),
-          output_channel_group_count(0),
-          output_channel_slice_offset(0),
-          output_h_mem_stride(0),
-          output_w_mem_stride(0) {}
-
     Params(const ImageGeometry &output_image, const ImageRegion &output_region,
            const int channels_per_group)
         : h_begin(output_region.start.row),

--- a/lib_nn/api/AggregateFn.hpp
+++ b/lib_nn/api/AggregateFn.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <vector>
 
+#include "Serialisable.hpp"
 #include "Utils.hpp"
 #include "geom/Filter2dGeometry.hpp"
 #include "vpu.hpp"
@@ -56,7 +57,7 @@ struct Conv2dReorderedWeights {
 
 class MatMulInt8 : public AggregateFn {
  public:
-  class Params {
+  class Params : public Serialisable {
    public:
     const int8_t *weights;
     const int32_t output_slice_channel_count;
@@ -131,7 +132,7 @@ class MatMulInt8 : public AggregateFn {
 
 class MatMulDirectFn : public AggregateFn {
  public:
-  class Params {
+  class Params : public Serialisable {
    public:
     const int8_t *weights;
 

--- a/lib_nn/api/MemCpyFn.hpp
+++ b/lib_nn/api/MemCpyFn.hpp
@@ -1,6 +1,7 @@
 #ifndef LIB_NN_MEMCPY_FN_HPP_
 #define LIB_NN_MEMCPY_FN_HPP_
 
+#include "Serialisable.hpp"
 #include "geom/Filter2dGeometry.hpp"
 
 namespace nn {
@@ -67,7 +68,7 @@ class MemCpyFn {
  */
 class DerefInputFn : public MemCpyFn {
  public:
-  class Params {
+  class Params : public Serialisable {
    public:
     int32_t bytes_per_h_line;
     int32_t bytes_per_pixel;
@@ -122,7 +123,7 @@ class DerefInputFn : public MemCpyFn {
  */
 class ImToColPadded : public MemCpyFn {
  public:
-  class Params {
+  class Params : public Serialisable {
    public:
     int32_t kernel_height;
     int32_t input_v_length;
@@ -207,7 +208,8 @@ class ImToColPadded : public MemCpyFn {
 
 class ImToColValid : public MemCpyFn {
  public:
-  struct Params {
+  class Params : public Serialisable {
+   public:
     /**
      * Bytes per row of the input image
      */
@@ -250,6 +252,7 @@ class ImToColValid : public MemCpyFn {
     // i.e. from X[h][w + kernel_width - 1] to X[h+1][w].
     int32_t vertical_mem_stride;
 
+   public:
     /**
      * @brief Construct a new Params object
      *

--- a/lib_nn/api/Serialisable.hpp
+++ b/lib_nn/api/Serialisable.hpp
@@ -1,0 +1,18 @@
+#ifndef LIB_NN_SERIALISABLE_HPP_
+#define LIB_NN_SERIALISABLE_HPP_
+
+#include <string>
+
+class Serialisable {
+ public:
+  template <class T>
+  std::string serialise() {
+    return std::string((char*)this, (char*)(this + sizeof(T)));
+  }
+  template <class T>
+  static T* deserialise(const char* buf) {
+    return (T*)buf;
+  }
+};
+
+#endif  // LIB_NN_SERIALISABLE_HPP_

--- a/test/gtests/src/op/ref/test_Conv2dRegression.cpp
+++ b/test/gtests/src/op/ref/test_Conv2dRegression.cpp
@@ -165,9 +165,9 @@ TEST_F(Conv2dPaddedIndirectRegression, BasicTest) {
                                       canonical_values.f_biases,
                                       canonical_values.accu_min,
                                       canonical_values.accu_max);
-                              OT_int8::Params ot_params(
-                                  (int32_t)k_depth, &qp.otv, qp.biases.data(),
-                                  qp.multipliers.data());
+                              OT_int8::Params ot_params((int32_t)k_depth,
+                                                        &qp.otv, qp.biases,
+                                                        qp.multipliers);
 
                               OT_int8 ot(&ot_params);
                               auto ir = ImageRegion(0, 0, 0, Y.height, Y.width,
@@ -340,9 +340,9 @@ TEST_F(Conv2dValidIndirectRegression, BasicTest) {
                                       canonical_values.f_biases,
                                       canonical_values.accu_min,
                                       canonical_values.accu_max);
-                              OT_int8::Params ot_params(
-                                  (int32_t)k_depth, &qp.otv, qp.biases.data(),
-                                  qp.multipliers.data());
+                              OT_int8::Params ot_params((int32_t)k_depth,
+                                                        &qp.otv, qp.biases,
+                                                        qp.multipliers);
 
                               OT_int8 ot(&ot_params);
                               auto ir = ImageRegion(0, 0, 0, Y.height, Y.width,
@@ -507,9 +507,9 @@ TEST_F(Conv2dValidDirectRegression, BasicTest) {
                                       canonical_values.f_biases,
                                       canonical_values.accu_min,
                                       canonical_values.accu_max);
-                              OT_int8::Params ot_params(
-                                  (int32_t)k_depth, &qp.otv, qp.biases.data(),
-                                  qp.multipliers.data());
+                              OT_int8::Params ot_params((int32_t)k_depth,
+                                                        &qp.otv, qp.biases,
+                                                        qp.multipliers);
                               OT_int8 ot(&ot_params);
                               auto ir = ImageRegion(0, 0, 0, Y.height, Y.width,
                                                     Y.depth);

--- a/test/gtests/src/test_OutputTransforms.cpp
+++ b/test/gtests/src/test_OutputTransforms.cpp
@@ -86,8 +86,8 @@ TEST_F(Test_OT_int8, BasicTest) {
       QuantisationParams qp = OutputTransformFnInt8::quantise_activation(
           f_multipliers, f_biases, accu_min, accu_max);
 
-      OT_int8::Params p((int32_t)output_ch_count, &qp.otv, qp.biases.data(),
-                        qp.multipliers.data());
+      OT_int8::Params p((int32_t)output_ch_count, &qp.otv, qp.biases,
+                        qp.multipliers);
 
       OT_int8 ot(&p);
 

--- a/test/gtests/src/test_Serialisation.cpp
+++ b/test/gtests/src/test_Serialisation.cpp
@@ -1,0 +1,103 @@
+#include <cstring>
+#include <vector>
+
+#include "AbstractKernel.hpp"
+#include "AggregateFn.hpp"
+#include "MemCpyFn.hpp"
+#include "OutputTransformFn.hpp"
+#include "Rand.hpp"
+#include "gtest/gtest.h"
+
+using namespace nn;
+using namespace nn::test;
+static auto rng = Rand(69);
+
+static const int test_count = 1 << 10;
+
+template <class T>
+void test_serialisation() {
+  int8_t d[sizeof(T)];
+
+  for (int t = 0; t < test_count; ++t) {
+    for (int idx = 0; idx < sizeof(T); ++idx) d[idx] = rng.rand<int8_t>();
+
+    T *p = (T *)d;
+    std::string s = p->template serialise<T>();
+    T *q = Serialisable::deserialise<T>(s.c_str());
+
+    for (size_t i = 0; i < sizeof(T); i++) {
+      EXPECT_EQ(((int8_t *)p)[i], ((int8_t *)q)[i]);
+    }
+  }
+}
+
+class Test_AbstractKernelParams : public ::testing::Test {};
+
+TEST_F(Test_AbstractKernelParams, BasicTest) {
+  test_serialisation<AbstractKernel::Params>();
+}
+
+class Test_ImToColValidParams : public ::testing::Test {};
+
+TEST_F(Test_ImToColValidParams, BasicTest) {
+  test_serialisation<ImToColValid::Params>();
+}
+
+class Test_ImToColPaddedParams : public ::testing::Test {};
+
+TEST_F(Test_ImToColPaddedParams, BasicTest) {
+  test_serialisation<ImToColPadded::Params>();
+}
+
+class Test_DerefInputFnParams : public ::testing::Test {};
+
+TEST_F(Test_DerefInputFnParams, BasicTest) {
+  test_serialisation<DerefInputFn::Params>();
+}
+
+class Test_MatMulInt8Params : public ::testing::Test {};
+
+TEST_F(Test_MatMulInt8Params, BasicTest) {
+  test_serialisation<MatMulInt8::Params>();
+}
+
+class Test_MatMulDirectFnParams : public ::testing::Test {};
+
+TEST_F(Test_MatMulDirectFnParams, BasicTest) {
+  test_serialisation<MatMulDirectFn::Params>();
+}
+
+class Test_OT_int8Params : public ::testing::Test {};
+
+TEST_F(Test_OT_int8Params, BasicTest) {
+  int8_t d[sizeof(OT_int8::Params)];
+
+  for (int t = 0; t < test_count; ++t) {
+    int output_slice_channel_count = t;
+    std::vector<int16_t> biases(output_slice_channel_count);
+    std::vector<int16_t> multipliers(output_slice_channel_count);
+    OutputTransformValues otv;
+
+    for (int idx = 0; idx < output_slice_channel_count; ++idx) {
+      biases[idx] = rng.rand<int16_t>();
+      multipliers[idx] = rng.rand<int16_t>();
+    }
+    for (int idx = 0; idx < sizeof(OutputTransformValues); ++idx) {
+      ((int8_t *)&otv)[idx] = rng.rand<int8_t>();
+    }
+
+    OT_int8::Params p(output_slice_channel_count, &otv, biases, multipliers);
+    std::string s = p.template serialise<OT_int8::Params>();
+    OT_int8::Params *q = Serialisable::deserialise<OT_int8::Params>(s.c_str());
+
+    EXPECT_EQ(p.output_slice_channel_count, q->output_slice_channel_count);
+
+    for (size_t i = 0; i < sizeof(OutputTransformValues); i++) {
+      EXPECT_EQ(((int8_t *)p.otv)[i], ((int8_t *)q->otv)[i]);
+    }
+    for (size_t i = 0; i < output_slice_channel_count; i++) {
+      EXPECT_EQ(p.biases[i], q->biases[i]);
+      EXPECT_EQ(p.multipliers[i], q->multipliers[i]);
+    }
+  }
+}


### PR DESCRIPTION
This adds serialisation to all params classes and it adds tests for them all. I also changed the interface to OT_int8::Params to take a vector rather than a pointer so that length checking can be added. 