### PR TITLE
Feature/memset 256

### DIFF
--- a/lib_nn/api/vpu_memmove_word_aligned.h
+++ b/lib_nn/api/vpu_memmove_word_aligned.h
@@ -4,7 +4,7 @@
 /**
  * Function that copies a block of memory. Both source and destination
  * address must be word aligned. Any number of bytes can be copied. There
- * should not be an overlap between the destination and source.
+ * may be an overlap between the destination and source.
  *
  * @param     dst         Destination address, must be word aligned.
  * @param     src         Source address, must be word aligned.

--- a/lib_nn/api/vpu_memmove_word_aligned.h
+++ b/lib_nn/api/vpu_memmove_word_aligned.h
@@ -1,0 +1,15 @@
+#ifndef _vpu_memmove_word_aligned_h_
+#define _vpu_memmove_word_aligned_h_
+
+/**
+ * Function that copies a block of memory. Both source and destination
+ * address must be word aligned. Any number of bytes can be copied. There
+ * should not be an overlap between the destination and source.
+ *
+ * @param     dst         Destination address, must be word aligned.
+ * @param     src         Source address, must be word aligned.
+ * @param     byte_count  Number of bytes to copy - may be zero
+ */
+void vpu_memmove_word_aligned(void * dst, const void * src, unsigned int byte_count);
+
+#endif

--- a/lib_nn/api/vpu_memset_256.h
+++ b/lib_nn/api/vpu_memset_256.h
@@ -1,0 +1,21 @@
+#ifndef _vpu_memset_256_h_
+#define _vpu_memset_256_h_
+
+/**
+ * Function that replicates a vector. The source address must be word
+ * aligned, the destination address is assumed to be aligned with the
+ * replication pattern in the source. Any number of bytes can be copied.
+ * There should not be an overlap between the destination and source.
+ * 
+ * It is assumed that the source address contains 32 replicated bytes (if
+ * the destination address is byte aligned), or that it contains 16
+ * replicated shorts (if the destination address is 16-bit aligned), or
+ * that it contains 8 replicated ints.
+ *
+ * @param     dst         Destination address
+ * @param     src         Source address, must be word aligned.
+ * @param     byte_count  Number of bytes to copy - may be zero
+ */
+void vpu_memset_256(void * dst, const void * src, unsigned int byte_count);
+
+#endif

--- a/lib_nn/api/vpu_memset_256.h
+++ b/lib_nn/api/vpu_memset_256.h
@@ -12,10 +12,41 @@
  * replicated shorts (if the destination address is 16-bit aligned), or
  * that it contains 8 replicated ints.
  *
+ * broadcast_32_to_256() and BROADCAST_8_TO_32() cane be used to
+ * create the source vector
+ *
  * @param     dst         Destination address
  * @param     src         Source address, must be word aligned.
  * @param     byte_count  Number of bytes to copy - may be zero
  */
 void vpu_memset_256(void * dst, const void * src, unsigned int byte_count);
+
+/**
+ * Function that replicates an int over a vector. The vector must be
+ * aligned on an 8-byte boundary. In order to replicate a byte or short over
+ * a vector, combine this with a call to BROADCAST_8_TO_32() or
+ * BROADCAST_16_TO_32()
+ *
+ * @param     dst         Destination address
+ * @param     from        Value to be replicated
+ */
+void broadcast_32_to_256(uint64_t *dst, uint32_t from);
+
+/**
+ * Macro that replicates a byte over an int.
+ * Use with broadcast_32_to_256() in order to replicate a byte over a vector
+ */
+#define BROADCAST_8_TO_32(f)   (((uint8_t)f) * 0x01010101)
+
+/**
+ * Macro that replicates a short over an int 
+ * Use with broadcast_32_to_256() in order to replicate a short over a vector
+ */
+#define BROADCAST_16_TO_32(f)  (((uint16_t)f) * 0x00010001)
+
+/**
+ * Macro that replicates a byte over a short
+ */
+#define BROADCAST_8_TO_16(f)   (((uint8_t)f) * 0x00000101)
 
 #endif

--- a/lib_nn/api/vpu_memset_256.h
+++ b/lib_nn/api/vpu_memset_256.h
@@ -25,12 +25,13 @@ void vpu_memset_256(void * dst, const void * src, unsigned int byte_count);
  * Function that replicates an int over a vector. The vector must be
  * aligned on an 8-byte boundary. In order to replicate a byte or short over
  * a vector, combine this with a call to BROADCAST_8_TO_32() or
- * BROADCAST_16_TO_32()
+ * BROADCAST_16_TO_32(). Declare the vector as a uint64_t x[] in order to
+ * guarantee 8-byte alignement.
  *
- * @param     dst         Destination address
+ * @param     dst         Destination address, must be 8-byte aligned
  * @param     from        Value to be replicated
  */
-void broadcast_32_to_256(uint64_t *dst, uint32_t from);
+void broadcast_32_to_256(void *dst, uint32_t from);
 
 /**
  * Macro that replicates a byte over an int.

--- a/lib_nn/src/asm/vpu_memmove_word_aligned.S
+++ b/lib_nn/src/asm/vpu_memmove_word_aligned.S
@@ -1,18 +1,23 @@
 // Copyright 2020-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#ifndef NN_USE_REF
 #include <xs1.h>
 
-// void vpu_memmove_word_aligned(void * dst, const void * src, int byte_count);
+// void vpu_memmove_word_aligned(void * dst, const void * src, unsigned byte_count);
 
-.globl vpu_memmove_word_aligned
-.globl vpu_memmove_word_aligned.nstackwords
-.linkset vpu_memmove_word_aligned.nstackwords,0
+#define FUNCTION_NAME vpu_memmove_word_aligned
+    
+#define NSTACKWORDS     0
 
-.align 16
-.issue_mode dual
+    .text
+	.cc_top FUNCTION_NAME.function,FUNCTION_NAME
 
-vpu_memmove_word_aligned:
-    { dualentsp 0                  ; shr r3, r2, 5}
+    .globl FUNCTION_NAME
+    .align 16
+    .issue_mode dual
+
+FUNCTION_NAME: 
+    { dualentsp NSTACKWORDS        ; shr r3, r2, 5}
     { bf  r3, .Ldone_whole_vectors ; lss r11, r0, r1 }
     { bf r11, .Lcopy_down          ; shl r11, r3, 5 }
     { ldc r11, 32                  ; sub r2, r2, r11}
@@ -27,7 +32,7 @@ vpu_memmove_word_aligned:
     { vldr r11[0]                  ; nop }
     vstrpv r0[0], r2
 
-	retsp 0
+	retsp NSTACKWORDS
 
 .Lcopy_down:
     { sub r2, r2, r11              ; add r0, r0, r11 }
@@ -44,4 +49,18 @@ vpu_memmove_word_aligned:
     { vstd r0[0]                   ; sub r3, r3, 1}
     { bt r3, .Lloop_down           ; sub r1, r1, r11}
 
-	retsp 0
+	retsp NSTACKWORDS
+    
+    .cc_bottom FUNCTION_NAME.function
+    .set FUNCTION_NAME.nstackwords,NSTACKWORDS
+    .globl FUNCTION_NAME.nstackwords
+    .set FUNCTION_NAME.maxcores,1
+    .globl FUNCTION_NAME.maxcores
+    .set FUNCTION_NAME.maxtimers,0
+    .globl FUNCTION_NAME.maxtimers
+    .set FUNCTION_NAME.maxchanends,0
+    .globl FUNCTION_NAME.maxchanends
+.Ltmp1:
+    .size FUNCTION_NAME, .Ltmp1-FUNCTION_NAME
+    
+#endif

--- a/lib_nn/src/asm/vpu_memmove_word_aligned.S
+++ b/lib_nn/src/asm/vpu_memmove_word_aligned.S
@@ -1,0 +1,47 @@
+// Copyright 2020-2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#include <xs1.h>
+
+// void vpu_memmove_word_aligned(void * dst, const void * src, int byte_count);
+
+.globl vpu_memmove_word_aligned
+.globl vpu_memmove_word_aligned.nstackwords
+.linkset vpu_memmove_word_aligned.nstackwords,0
+
+.align 16
+.issue_mode dual
+
+vpu_memmove_word_aligned:
+    { dualentsp 0                  ; shr r3, r2, 5}
+    { bf  r3, .Ldone_whole_vectors ; lss r11, r0, r1 }
+    { bf r11, .Lcopy_down          ; shl r11, r3, 5 }
+    { ldc r11, 32                  ; sub r2, r2, r11}
+
+.Lloop:
+    { vldd r1[0]                   ; add r1, r1, r11}
+    { vstd r0[0]                   ; sub r3, r3, 1}
+    { bt r3, .Lloop                ; add r0, r0, r11}
+
+.Ldone_whole_vectors:
+    { add  r11, r1, 0              ; mkmsk r2, r2 }
+    { vldr r11[0]                  ; nop }
+    vstrpv r0[0], r2
+
+	retsp 0
+
+.Lcopy_down:
+    { sub r2, r2, r11              ; add r0, r0, r11 }
+    add r1, r1, r11
+
+    { add  r11, r1, 0              ; mkmsk r2, r2 }
+    { vldr r11[0]                  ; ldc r11, 32 }
+    vstrpv r0[0], r2
+    sub r1, r1, r11
+                      
+
+.Lloop_down:
+    { vldd r1[0]                   ; sub r0, r0, r11}
+    { vstd r0[0]                   ; sub r3, r3, 1}
+    { bt r3, .Lloop_down           ; sub r1, r1, r11}
+
+	retsp 0

--- a/lib_nn/src/asm/vpu_memset_256.S
+++ b/lib_nn/src/asm/vpu_memset_256.S
@@ -1,0 +1,61 @@
+// Copyright 2020-2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#ifndef NN_USE_REF
+#include <xs1.h>
+
+// void vpu_memset_256(void * dst, const void * src, unsigned byte_count);
+
+#define FUNCTION_NAME vpu_memset_256
+    
+#define NSTACKWORDS     0
+
+    .text
+	.cc_top FUNCTION_NAME.function,FUNCTION_NAME
+
+    .globl FUNCTION_NAME
+    .align 16
+    .issue_mode dual
+
+FUNCTION_NAME: 
+    { dualentsp NSTACKWORDS        ; add r11, r1, 0 }
+    { vldr   r11[0]                ; add r1, r0, 0 }
+    { zext  r1, 2                  ; shr r3, r2, 5 }  // r3: vectors
+    { bf  r1, .Laligned            ; mkmsk r11, r2 }
+
+    
+    { shl   r11, r11, r1           ; sub   r2, r2, 4 }
+    { sub   r0, r0, r1             ; add   r2, r2, r1}
+
+    vstrpv r0[0], r11
+    add   r0, r0, 4
+
+    ashr  r3, r2, 32
+    { bt    r3, .Ldone             ; shr   r3, r2, 5 }
+
+.Laligned:
+    { bf  r3, .Ldone_whole_vectors ; shl r11, r3, 5 }
+    { ldc r11, 32                  ; sub r2, r2, r11}
+
+.Lloop:
+    { vstr r0[0]                   ; sub r3, r3, 1}
+    { bt r3, .Lloop                ; add r0, r0, r11}
+
+.Ldone_whole_vectors:
+    { mkmsk r2, r2                  ; nop }
+    vstrpv r0[0], r2
+.Ldone:
+	retsp NSTACKWORDS
+    
+    .cc_bottom FUNCTION_NAME.function
+    .set FUNCTION_NAME.nstackwords,NSTACKWORDS
+    .globl FUNCTION_NAME.nstackwords
+    .set FUNCTION_NAME.maxcores,1
+    .globl FUNCTION_NAME.maxcores
+    .set FUNCTION_NAME.maxtimers,0
+    .globl FUNCTION_NAME.maxtimers
+    .set FUNCTION_NAME.maxchanends,0
+    .globl FUNCTION_NAME.maxchanends
+.Ltmp1:
+    .size FUNCTION_NAME, .Ltmp1-FUNCTION_NAME
+    
+#endif

--- a/lib_nn/src/c/vpu_memmove_word_aligned.c
+++ b/lib_nn/src/c/vpu_memmove_word_aligned.c
@@ -1,8 +1,8 @@
-#include <stdlib.h>
+#include <string.h>
 #include "vpu_memmove_word_aligned.h"
 
 #ifdef NN_USE_REF
-void vpu_memmove_word_aligned(void * dst, const void * src, int byte_count) {
+void vpu_memmove_word_aligned(void * dst, const void * src, unsigned byte_count) {
     memmove(dst, src, byte_count);
 }
 #endif

--- a/lib_nn/src/c/vpu_memmove_word_aligned.c
+++ b/lib_nn/src/c/vpu_memmove_word_aligned.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+#include "vpu_memmove_word_aligned.h"
+
+#ifdef NN_USE_REF
+void vpu_memmove_word_aligned(void * dst, const void * src, int byte_count) {
+    memmove(dst, src, byte_count);
+}
+#endif

--- a/lib_nn/src/c/vpu_memset_256.c
+++ b/lib_nn/src/c/vpu_memset_256.c
@@ -11,3 +11,16 @@ void vpu_memset_256(void * dst, const void * src, unsigned byte_count) {
     }
 }
 #endif
+
+void broadcast_32_to_256(uint64_t *dst, uint32_t from) {
+#ifdef NN_USE_REF
+    for(int i = 0; i < 8; i++) {
+        ((uint32_t *)dst)[i] = from;
+    }
+#else
+    asm("std %0, %1, %2[0]" :: "r" (from), "r" (from), "r" (dst));
+    asm("std %0, %1, %2[1]" :: "r" (from), "r" (from), "r" (dst));
+    asm("std %0, %1, %2[2]" :: "r" (from), "r" (from), "r" (dst));
+    asm("std %0, %1, %2[3]" :: "r" (from), "r" (from), "r" (dst));
+#endif
+}

--- a/lib_nn/src/c/vpu_memset_256.c
+++ b/lib_nn/src/c/vpu_memset_256.c
@@ -12,7 +12,7 @@ void vpu_memset_256(void * dst, const void * src, unsigned byte_count) {
 }
 #endif
 
-void broadcast_32_to_256(uint64_t *dst, uint32_t from) {
+void broadcast_32_to_256(void *dst, uint32_t from) {
 #ifdef NN_USE_REF
     for(int i = 0; i < 8; i++) {
         ((uint32_t *)dst)[i] = from;

--- a/lib_nn/src/c/vpu_memset_256.c
+++ b/lib_nn/src/c/vpu_memset_256.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+#include <string.h>
+#include "vpu_memset_256.h"
+
+#ifdef NN_USE_REF
+void vpu_memset_256(void * dst, const void * src, unsigned byte_count) {
+    int s = ((int) dst) & 3;
+    for(int i = 0; i < byte_count; i++) {
+        ((uint8_t *)dst)[i] = ((uint8_t *)src)[s];
+        s = (s + 1) & 31;
+    }
+}
+#endif

--- a/test/unit_test/src/main.c
+++ b/test/unit_test/src/main.c
@@ -43,5 +43,6 @@ int main(void) {
   CALL(test_add_int16);
 
   CALL(test_vpu_memmove_aligned);
+  CALL(test_vpu_memset_256);
   return UNITY_END();
 }

--- a/test/unit_test/src/main.c
+++ b/test/unit_test/src/main.c
@@ -42,5 +42,6 @@ int main(void) {
   CALL(test_quantize_int16);
   CALL(test_add_int16);
 
+  CALL(test_vpu_memmove_aligned);
   return UNITY_END();
 }

--- a/test/unit_test/src/test_vpu_memmove_word_aligned.c
+++ b/test/unit_test/src/test_vpu_memmove_word_aligned.c
@@ -1,0 +1,108 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "math.h"
+
+#include "vpu_memmove_word_aligned.h"
+
+#include "tst_common.h"
+#ifdef LOCAL_MAIN
+    #undef UNITY_SET_FILE
+int intbits(float f) {
+    return *(int *)&f;
+}
+#define UNITY_SET_FILE()
+#define RUN_TEST(x) x()
+#define TEST_ASSERT_EQUAL(a, b) if ((a) != (b)) {printf("Expected %08x saw %08x\n", (int) a, (int) b); errors++;}
+#define TEST_ASSERT_EQUAL_FLOAT(a, b) if ((a) != (b)) {printf("Expected %f saw %f (%08x != %08x)\n", a, b, intbits(a), intbits(b)); errors++;}
+#define TEST_ASSERT_INT_WITHIN(d, a, b) if (abs((a)-(b)) > (d)) {printf("Expected %08x +/- %d saw %08x\n", (int) (a), (int) (d), (int) (b)); errors++;}
+#else
+#include "unity.h"
+#endif
+
+#define N 25
+
+int test_vpu_memmove_word_aligned(void) {
+    int mem1[32];
+    int mem2[32];
+    int dst_vals[] = {0, 4, 28};
+    int len_vals[] = {0, 1, 2, 3, 4, 5, 16, 30, 31, 32, 33, 34, 35, 36, 37, 38, 59, 60, 61, 62, 63};
+    int errors = 0;
+    for(int len_index = 0; len_index < sizeof(len_vals)/sizeof(int); len_index++) {
+        int len = len_vals[len_index];
+        for(int src = 0; src < 32; src+=28) {
+            for(int dst_index = 0; dst_index < sizeof(dst_vals)/sizeof(int); dst_index++) {
+                int dst = dst_vals[dst_index];
+//                printf("Dst %d src %d len %d  2->1\n", dst, src, len);
+                // First try mem2->mem1
+                for(int k = 0; k < 32; k++) {
+                    mem1[k] = 0;
+                }
+                for(int k = 0; k < len; k++) {
+                    ((uint8_t *)mem2)[k+src] = k+0x40;
+                }
+                vpu_memmove_word_aligned(((uint8_t*)mem1)+dst, ((uint8_t*)mem2)+src, len);
+                if (dst != 0) {
+                    TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst-1], 0);
+                }
+                for(int k = 0; k < len; k++) {
+                    TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst+k], k+0x40);
+                }
+                TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst+len], 0);
+
+                // Now try mem1->mem2
+//                printf("Dst %d src %d len %d  1->2\n", dst, src, len);
+
+                for(int k = 0; k < 32; k++) {
+                    mem2[k] = 0;
+                }
+                for(int k = 0; k < len; k++) {
+                    ((uint8_t *)mem1)[k+src] = k+0x40;
+                }
+                vpu_memmove_word_aligned(((uint8_t*)mem2)+dst, ((uint8_t*)mem1)+src, len);
+                if (dst != 0) {
+                    TEST_ASSERT_EQUAL(((uint8_t *)mem2)[dst-1], 0);
+                }
+                for(int k = 0; k < len; k++) {
+                    TEST_ASSERT_EQUAL(((uint8_t *)mem2)[dst+k], k+0x40);
+                }
+                TEST_ASSERT_EQUAL(((uint8_t *)mem2)[dst+len], 0);
+                
+//                printf("Dst %d src %d len %d  2->2\n", dst, src, len);
+                // Now overlap mem2+src->mem2+dst
+                for(int k = 0; k < 32; k++) {
+                    mem2[k] = 0;
+                }
+                for(int k = 0; k < len; k++) {
+                    ((uint8_t *)mem2)[k+src] = k+0x40;
+                }
+                vpu_memmove_word_aligned(((uint8_t*)mem2)+dst, ((uint8_t*)mem2)+src, len);
+                if (dst != 0) {
+                    TEST_ASSERT_EQUAL(((uint8_t *)mem2)[dst-1], src >= dst || len == 0 || dst-1-src >= len? 0x00: dst-1-src+0x40);
+                }
+                for(int k = 0; k < len; k++) {
+                    TEST_ASSERT_EQUAL(((uint8_t *)mem2)[dst+k], k+0x40);
+                }
+                TEST_ASSERT_EQUAL(((uint8_t *)mem2)[dst+len], src <= dst || len == 0 || dst+len-src >= len || dst+len-src < 0 ? 0x00 : dst+len-src+0x40);
+            }
+        }
+    }
+    return errors;
+}
+
+void test_vpu_memmove_aligned() {
+  UNITY_SET_FILE();
+  RUN_TEST(test_vpu_memmove_word_aligned);
+}
+
+#ifdef LOCAL_MAIN
+
+int main(void) {
+    int errors = 0;
+    errors += test_vpu_memmove_word_aligned();
+    if (errors != 0) printf("FAIL\n"); else printf("PASS\n");
+    return errors;
+}
+
+#endif

--- a/test/unit_test/src/test_vpu_memset_vector.c
+++ b/test/unit_test/src/test_vpu_memset_vector.c
@@ -43,15 +43,12 @@ int test_vpu_memset256(void) {
     for(int len_index = 0; len_index < sizeof(len_vals)/sizeof(int); len_index++) {
         int len = len_vals[len_index];
         for(int dst_index = 0; dst_index < sizeof(dst_vals)/sizeof(int); dst_index++) {
-            unsigned t0, t1;
             int dst = dst_vals[dst_index];
 //            printf("Dst %d  len %d  \n", dst, len);
             for(int k = 0; k < 32; k++) {
                 mem1[k] = 0;
             }
-            asm volatile("gettime %0" : "=r" (t0));
             vpu_memset_256(((uint8_t*)mem1)+dst, ((uint8_t*)(from[dst&3])), len);
-            asm volatile("gettime %0" : "=r" (t1));
             time += t1-t0;
             TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst-1], 0);
             int cnt = dst;
@@ -62,7 +59,6 @@ int test_vpu_memset256(void) {
             TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst+len], 0);
         }
     }
-//    printf("%d ticks\n", time);
     return errors;
 }
 

--- a/test/unit_test/src/test_vpu_memset_vector.c
+++ b/test/unit_test/src/test_vpu_memset_vector.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "math.h"
+
+#include "vpu_memset_256.h"
+
+#include "tst_common.h"
+#ifdef LOCAL_MAIN
+    #undef UNITY_SET_FILE
+int intbits(float f) {
+    return *(int *)&f;
+}
+#define UNITY_SET_FILE()
+#define RUN_TEST(x) x()
+#define TEST_ASSERT_EQUAL(a, b) if ((a) != (b)) {printf("Expected %08x saw %08x\n", (int) a, (int) b); errors++;}
+#define TEST_ASSERT_EQUAL_FLOAT(a, b) if ((a) != (b)) {printf("Expected %f saw %f (%08x != %08x)\n", a, b, intbits(a), intbits(b)); errors++;}
+#define TEST_ASSERT_INT_WITHIN(d, a, b) if (abs((a)-(b)) > (d)) {printf("Expected %08x +/- %d saw %08x\n", (int) (a), (int) (d), (int) (b)); errors++;}
+#else
+#include "unity.h"
+#endif
+
+#define N 25
+
+int test_vpu_memset256(void) {
+    int mem1[32];
+    int from[4][8] =
+        {
+            {0x80706050, 0x80706050, 0x80706050, 0x80706050,
+             0x80706050, 0x80706050, 0x80706050, 0x80706050}, // int32
+            {0x80808080, 0x80808080, 0x80808080, 0x80808080,
+             0x80808080, 0x80808080, 0x80808080, 0x80808080}, // int8
+            {0x80708070, 0x80708070, 0x80708070, 0x80708070,
+             0x80708070, 0x80708070, 0x80708070, 0x80708070}, // int16
+            {0x80808080, 0x80808080, 0x80808080, 0x80808080,
+             0x80808080, 0x80808080, 0x80808080, 0x80808080}, // int8
+        };
+    int dst_vals[] = {1, 2, 3, 4, 5};
+    int len_vals[] = {0, 1, 2, 3, 4, 5, 16, 30, 31, 32, 33, 34, 35, 36, 37, 38, 59, 60, 61, 62, 63};
+    int errors = 0;
+    int time = 0;
+    for(int len_index = 0; len_index < sizeof(len_vals)/sizeof(int); len_index++) {
+        int len = len_vals[len_index];
+        for(int dst_index = 0; dst_index < sizeof(dst_vals)/sizeof(int); dst_index++) {
+            unsigned t0, t1;
+            int dst = dst_vals[dst_index];
+//            printf("Dst %d  len %d  \n", dst, len);
+            for(int k = 0; k < 32; k++) {
+                mem1[k] = 0;
+            }
+            asm volatile("gettime %0" : "=r" (t0));
+            vpu_memset_256(((uint8_t*)mem1)+dst, ((uint8_t*)(from[dst&3])), len);
+            asm volatile("gettime %0" : "=r" (t1));
+            time += t1-t0;
+            TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst-1], 0);
+            int cnt = dst;
+            for(int k = 0; k < len; k++) {
+                TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst+k], ((uint8_t*)(from[dst&3]))[cnt]);
+                cnt = (cnt + 1) & 31;
+            }
+            TEST_ASSERT_EQUAL(((uint8_t *)mem1)[dst+len], 0);
+        }
+    }
+//    printf("%d ticks\n", time);
+    return errors;
+}
+
+void test_vpu_memset_256() {
+  UNITY_SET_FILE();
+  RUN_TEST(test_vpu_memset256);
+}
+
+#ifdef LOCAL_MAIN
+
+int main(void) {
+    int errors = 0;
+    errors += test_vpu_memset256();
+    if (errors != 0) printf("FAIL\n"); else printf("PASS\n");
+    return errors;
+}
+
+#endif


### PR DESCRIPTION
Function that memset a stencil of 256 bits over a destination. The destination is assumed to be aligned with the vector in the source; ie, if the destination is at address 0x80001 it will copy bytes from index 1 onwards in the source vector.

This ought to replace memset32.