### PR TITLE
Fix the infinite loop in mul_boggle

### DIFF
--- a/lib_nn/src/c/mul.c
+++ b/lib_nn/src/c/mul.c
@@ -18,9 +18,9 @@ static int32_t clamp(int32_t v, int32_t lo, int32_t hi){
 
 void mul_elementwise_asm(const int8_t* in1_data, const int8_t* in2_data, int element_count, nn_mul_params_t * params, int8_t * out_data);
 
-static const unsigned vlsat_shr = 1;
+static const signed vlsat_shr = 1;
 static const unsigned vlmul_shr = 14;
-static const unsigned vdepth8_shr = 8;
+static const signed vdepth8_shr = 8;
 
 void mul_boggle(nn_mul_params_t * params, 
     double in1Scale, 


### PR DESCRIPTION
The function mul_boggle will find the closest output scale and bias, and vlashr_shr parameters such that it will not overflow in vpu calculation.

The current code will have an infinite loop when the required vlashr_shr is smaller than vdepth8_shr or (vlsat_shr + vlmul_shr + vdepth8_shr).
As vdepth8_shr and vlsat_shr are unsigned variable, it will underflow when vlashr_shr is too small.
This cause pow(2, y) in [L51](https://github.com/LeslieXMOS/lib_nn/blob/dbe366180ef12737395132444ca9660a2ae78806/lib_nn/src/c/mul.c#L51) and [L63](https://github.com/LeslieXMOS/lib_nn/blob/dbe366180ef12737395132444ca9660a2ae78806/lib_nn/src/c/mul.c#L63) can never output value smaller than 1, thus the loop never ends.

This pull request updated vdepth8_shr and vlsat_shr to signed variable, prevent underflow in the operation.