### PR TITLE
Remove empty stubs

### DIFF
--- a/lib_nn/src/asm/stubs.c
+++ b/lib_nn/src/asm/stubs.c
@@ -1,4 +1,4 @@
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 #include "nn_operator.h"
 #include "../src/asm/asm_constants.h"
 #include "vpu_sim.h"
@@ -32,11 +32,6 @@ void requantize_int16_tensor_asm(int16_t *output, int16_t *input1, int tensor_le
     requantize_int16_tensor_ref(output, input1, tensor_length, blob);
 }
 
-void output_transform_fn_int16_impl_asm(int16_t *vDvR,
-                                        int32_t *mul_add,
-                                        int16_t *output,
-                                        uint32_t N);
-
 void pad_3_to_4_asm(int32_t outputs[], int64_t inputs[], uint32_t N_24, uint32_t pad_val) {
     int8_t * outputs_p = (int8_t *)outputs;
     int8_t * inputs_p = inputs;
@@ -51,36 +46,26 @@ void pad_3_to_4_asm(int32_t outputs[], int64_t inputs[], uint32_t N_24, uint32_t
     }
 };
 
-int8_t *output_transform_maxpool_impl_asm(
-    const void *params, int8_t *Y, void *A,
-    int16_t *multipliers_and_biases, int output_count) {}
-int8_t *output_transform_fn_int_clamped_impl_asm(
-    const void *params, int8_t *Y, void *A,
-    int32_t output_channel_group, int16_t *offsets_multipliers_and_biases) {}
-int8_t *output_transform_fn_binary_impl_asm(
-    int8_t *Y, void *A, int32_t output_channel_group,
-    int16_t *thresholds) {}
+int16_t *output_transform_fn_int16_impl(int16_t *vDvR,
+                                        int32_t *mul_add,
+                                        int16_t *output,
+                                        uint32_t N);
 void output_transform_fn_int16_impl_asm(int16_t *vDvR,
                                         int32_t *mul_add,
                                         int16_t *output,
-                                        uint32_t N) {}
+                                        uint32_t N) {
+    output_transform_fn_int16_impl(vDvR, mul_add, output, N);
+}
+
+void quantize_int16_tensor_ref(int16_t *output, float *input, int tensor_length, void *blob);
 void quantize_int16_tensor_asm(int16_t *output,
-                               float *input, int tensor_length, void *blob) {}
-void mat_mul_direct_binary_impl_asm(const void *params,
-                                    void *A, int8_t *X,
-                                    int32_t output_channel_group,
-                                    int8_t *weights) {}
-void mat_mul_generic_binary_impl_asm(const void *params,
-                                     void *A, int8_t *X,
-                                     int32_t output_channel_group,
-                                     int8_t *weights) {}
-void maxpool_direct_impl_asm(const void *params, void *A, int8_t *X) {}
-void mat_mul_dw_direct_int16_impl_asm(const void *params,
-                                      void *A, int16_t *X,
-                                      int32_t output_channel_group,
-                                      int16_t *weights) {}
+                               float *input, int tensor_length, void *blob) {
+    quantize_int16_tensor_ref(output, input, tensor_length, blob);
+}
+
+// This empty stub here is to pass the build, this will not be called
 int8_t *output_transform_fn_int_channelwise_impl_asm(
     const void *params, int8_t *Y, void *A,
-    int16_t *multipliers_and_biases, int output_count) {}
+    int16_t *multipliers_and_biases, int output_count) {return NULL;}
 
 #endif

--- a/lib_nn/src/c/output_transform_fn_int16.c
+++ b/lib_nn/src/c/output_transform_fn_int16.c
@@ -12,7 +12,7 @@
 int min(int a, int b) {
     return a < b ? a : b;
 }
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore) 
 
 int16_t *output_transform_fn_int16_impl(int16_t *vDvR,
                                         int32_t *mul_add,
@@ -57,7 +57,7 @@ int16_t *output_transform_fn_int16(otfn_int16_params_t *params,
         (int32_t)VPU_INT16_EPV);
     //
     mul_add += output_channel_group * VPU_INT32_EPV * 4;
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
     return output_transform_fn_int16_impl(vDvR, mul_add,
                                           Y, output_count);
 #else

--- a/lib_nn/src/c/pad_1_to_4.c
+++ b/lib_nn/src/c/pad_1_to_4.c
@@ -27,7 +27,7 @@ void pad_1_to_4_ref(int8_t outputs[], int8_t inputs[], uint32_t N, uint32_t pad_
 }
 
 void pad_1_to_4_run(int8_t outputs[], int8_t inputs[], uint32_t N, uint32_t pad_val) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
         pad_1_to_4_ref(outputs, inputs, N, pad_val);
 #else
         pad_1_to_4_asm((int32_t *) outputs, (int32_t *)inputs, N, pad_val);

--- a/lib_nn/src/c/pad_3_to_4.c
+++ b/lib_nn/src/c/pad_3_to_4.c
@@ -72,7 +72,7 @@ void pad_3_to_4_run(int8_t outputs[], int8_t inputs[], uint32_t N_3, uint32_t pa
     // Now copy the bulk of the data in blocks of 24
     if (N_24 != 0) {
 
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
         int8_t * outputs_p = (int8_t *)outputs;
         int8_t * inputs_p = inputs;
         for(uint32_t l=0;l<N_24;l++){

--- a/lib_nn/src/c/vpu_sim.c
+++ b/lib_nn/src/c/vpu_sim.c
@@ -485,6 +485,9 @@ void VLMUL(xs3_vpu *vpu, const void *addr) {
     for (int i = 0; i < VPU_INT8_EPV; i++) {
       int32_t val = addr8[i];
       int32_t res = ((int32_t)vpu->vR.s8[i] * val + (1<<5)) >> 6;  // TODO use macros
+      if (NN_ARCH == TARGET_ARCH_VX4A){
+        res = res >> 1;
+      }
       vpu->vR.s8[i] = vpu_saturate(res, 8);
     }
   } else if (vpu->mode == MODE_S16) {

--- a/lib_nn/src/cpp/AggregateFn.cpp
+++ b/lib_nn/src/cpp/AggregateFn.cpp
@@ -328,7 +328,7 @@ void nn::mat_mul_direct_int8(const mat_mul_direct_params_t *params, VPURingBuffe
 
 void nn::mat_mul_direct_binary(const mat_mul_direct_params_t *params, VPURingBuffer *A, int8_t *T,
                                         int32_t output_channel_group, int8_t *weights) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   mat_mul_direct_binary_impl(params, A, T, output_channel_group, weights);
 #else
   mat_mul_direct_binary_impl_asm(params, A, T, output_channel_group,
@@ -347,7 +347,7 @@ void nn::mat_mul_generic_int8(const mat_mul_generic_params_t *params, VPURingBuf
 }
 void nn::mat_mul_generic_binary(const mat_mul_generic_params_t *params, VPURingBuffer *A, int8_t *T,
                                 int32_t output_channel_group, int8_t *weights) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   mat_mul_generic_binary_impl(params, A, T, output_channel_group,
                               weights);
 #else

--- a/lib_nn/src/cpp/AggregateFn_DW.cpp
+++ b/lib_nn/src/cpp/AggregateFn_DW.cpp
@@ -166,7 +166,7 @@ C_API void maxpool_direct_impl_asm(const mat_mul_dw_direct_params_t *params,
 
 void nn::maxpool_direct(const mat_mul_dw_direct_params_t *params,
                         VPURingBuffer *A, int8_t *T) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   maxpool_direct_impl(params, A, T);
 #else
   maxpool_direct_impl_asm(params, A, T);
@@ -250,7 +250,7 @@ void nn::mat_mul_dw_direct(const mat_mul_dw_direct_params_t *params, VPURingBuff
 
 void nn::mat_mul_dw_direct_int16(const mat_mul_dw_direct_params_t *params, VPURingBuffer *A, int16_t *T,
                                      int32_t output_channel_group, int16_t *weights) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   mat_mul_dw_direct_int16_impl(params, A, T, output_channel_group, weights);
 #else
   mat_mul_dw_direct_int16_impl_asm(params, A, T, output_channel_group, weights);

--- a/lib_nn/src/cpp/OutputTransformFn.cpp
+++ b/lib_nn/src/cpp/OutputTransformFn.cpp
@@ -891,7 +891,7 @@ int8_t *output_transform_fn_int_channelwise_impl(
 
 int8_t *nn::otfn_int8_channelwise(const otfn_int8_channelwise_params_t *params, int8_t *Y, VPURingBuffer *A,
                                                  int32_t output_channel_group, int16_t *multipliers_and_biases) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   return output_transform_fn_int_channelwise_impl(
       params, Y, A, output_channel_group, multipliers_and_biases);
 #else
@@ -937,7 +937,7 @@ int8_t *output_transform_fn_int_maxpool_impl(
 
 int8_t *nn::otfn_int8_maxpool(const otfn_int8_channelwise_params_t *params, int8_t *Y, VPURingBuffer *A,
                                                  int32_t output_channel_group, int16_t *multipliers_and_biases) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   return output_transform_fn_int_maxpool_impl(
       params, Y, A, output_channel_group, multipliers_and_biases);
 #else
@@ -1001,7 +1001,7 @@ extern "C" int8_t *output_transform_fn_int_clamped_impl_asm(
 
 int8_t *nn::otfn_int8_clamped(const otfn_int8_clamped_params_t *params, int8_t *Y, VPURingBuffer *A,
                                              int32_t output_channel_group, int16_t *offsets_multipliers_and_biases) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
 
   return output_transform_fn_int_clamped_impl(
       params, Y, A, output_channel_group, offsets_multipliers_and_biases);
@@ -1050,7 +1050,7 @@ extern "C" int8_t *output_transform_fn_binary_impl_asm(
 
 int8_t *nn::otfn_binary(void *p, int8_t *Y, VPURingBuffer *A,
                                        int32_t output_channel_group, int16_t *thresholds) {
-#ifdef NN_USE_REF
+#if defined(NN_USE_REF) || defined(__riscv_xxcore)
   return output_transform_fn_binary_impl(Y, A, output_channel_group,
                                          thresholds);
 #else


### PR DESCRIPTION
Remove the empty stubs implementation.
In cpp files, choose to use the reference implementation when macro __riscv_xxcore is set.