### PR TITLE
Update Dockerfile to use miniconda3:25.3.1-1 and clang version 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN chmod -R 777 /opt/conda \
     && conda init \
     && conda config --set auto_activate_base false
 
+# give conda a writable package cache for non-root users (e.g. Jenkins)
+ENV CONDA_PKGS_DIRS=/tmp/conda_pkgs
+RUN mkdir -p $CONDA_PKGS_DIRS /home/jenkins/.cache \
+    && chmod -R 777 $CONDA_PKGS_DIRS /home/jenkins/.cache
+
 # install tools lib dependencies
 RUN apt-get update && apt-get install -y \
     libncurses5 libncurses5-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.10.3
+FROM continuumio/miniconda3:25.3.1-1
 
 # This Dockerfile is for use by the XMOS CI system
 # It provides a minimal environment needed to execute the Jenkinsfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y \
     gnupg lsb-release software-properties-common
 ADD https://apt.llvm.org/llvm.sh /tmp/
-ARG clang_version=12
+ARG clang_version=16
 RUN cd /tmp \
     && chmod +x llvm.sh \
     && ./llvm.sh $clang_version


### PR DESCRIPTION
Because the image that we are using is continuumio/miniconda3:4.10.3 and is based on Debian buster, we cannot install deps any more due to the repos being sunset.

Switching to 25.3.1-1 which is Debian bookworm. This also entails upgrading to clang 16 as 12 is not available in bookworm from llvm.

Also added a writable cache folder for non root users for the conda step.