### PR TITLE
Make sure VX4B can build

### DIFF
--- a/lib_nn/src/asm/add_elementwise.S
+++ b/lib_nn/src/asm/add_elementwise.S
@@ -190,7 +190,7 @@ FUNCTION_NAME:
 
 #endif
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 
 #define FUNCTION_NAME add_elementwise_asm

--- a/lib_nn/src/asm/add_int16.S
+++ b/lib_nn/src/asm/add_int16.S
@@ -123,7 +123,7 @@ done:
 #endif
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 shifts:
     .word 0x000E000E, 0x000E000E, 0x000E000E, 0x000E000E

--- a/lib_nn/src/asm/aggregate_fn_direct_int16.S
+++ b/lib_nn/src/asm/aggregate_fn_direct_int16.S
@@ -119,7 +119,7 @@ FUNCTION_NAME:
 #endif
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 /*
 void mat_mul_impl_asm(void *params, VPURingBuffer *A, int8_t *X, int32_t output_channel_group);

--- a/lib_nn/src/asm/aggregate_fn_direct_int16x8.S
+++ b/lib_nn/src/asm/aggregate_fn_direct_int16x8.S
@@ -1,6 +1,6 @@
 // Copyright 2025 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 /*
 void mat_mul_direct_int16x8_impl_asm(

--- a/lib_nn/src/asm/aggregate_fn_direct_int8.S
+++ b/lib_nn/src/asm/aggregate_fn_direct_int8.S
@@ -147,7 +147,7 @@ FUNCTION_NAME:
 
 #endif
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 /*
 void mat_mul_impl_asm(void *params, VPURingBuffer *A, int8_t *X, int32_t output_channel_group);

--- a/lib_nn/src/asm/aggregate_fn_direct_int8_dw.S
+++ b/lib_nn/src/asm/aggregate_fn_direct_int8_dw.S
@@ -120,7 +120,7 @@ FUNCTION_NAME:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 
 #define FUNCTION_NAME mat_mul_dw_direct_impl_asm

--- a/lib_nn/src/asm/aggregate_fn_generic_int8.S
+++ b/lib_nn/src/asm/aggregate_fn_generic_int8.S
@@ -160,7 +160,7 @@ FUNCTION_NAME:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 
 #define FUNCTION_NAME mat_mul_generic_int8_impl_asm

--- a/lib_nn/src/asm/memcpy_fn_valid.S
+++ b/lib_nn/src/asm/memcpy_fn_valid.S
@@ -128,7 +128,7 @@ dont_zero_asm:
 #endif
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 
 //Registers

--- a/lib_nn/src/asm/mul_elementwise.S
+++ b/lib_nn/src/asm/mul_elementwise.S
@@ -206,7 +206,7 @@ FUNCTION_NAME:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 
 #define FUNCTION_NAME mul_elementwise_asm

--- a/lib_nn/src/asm/output_transform_fn_int8.S
+++ b/lib_nn/src/asm/output_transform_fn_int8.S
@@ -169,7 +169,7 @@ vlsat_done:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 #define FUNCTION_NAME output_transform_fn_impl_asm
 

--- a/lib_nn/src/asm/vpu_memcpy.S
+++ b/lib_nn/src/asm/vpu_memcpy.S
@@ -91,7 +91,7 @@ done:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 #define FUNCTION_NAME vpu_memcpy_vector_ext_asm
 

--- a/lib_nn/src/asm/vpu_memmove_word_aligned.S
+++ b/lib_nn/src/asm/vpu_memmove_word_aligned.S
@@ -68,7 +68,7 @@ FUNCTION_NAME:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 
 #define FUNCTION_NAME vpu_memmove_word_aligned

--- a/lib_nn/src/asm/vpu_memset32.S
+++ b/lib_nn/src/asm/vpu_memset32.S
@@ -37,7 +37,7 @@ early_exit:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 
 #define FUNCTION_NAME vpu_memset32_asm
 

--- a/lib_nn/src/asm/vpu_memset_256.S
+++ b/lib_nn/src/asm/vpu_memset_256.S
@@ -64,7 +64,7 @@ FUNCTION_NAME:
 
 
 
-#if defined(__VX4A__)
+#if defined(__VX4A__) || defined(__VX4B__)
 // void vpu_memset_256(void * dst, const void * src, unsigned byte_count);
 
 #define FUNCTION_NAME vpu_memset_256

--- a/lib_nn/src/c/vpu_memset_256.c
+++ b/lib_nn/src/c/vpu_memset_256.c
@@ -24,7 +24,7 @@ void broadcast_32_to_256(void *dst, uint32_t from) {
     asm("std %0, %1, %2[2]" :: "r" (from), "r" (from), "r" (dst));
     asm("std %0, %1, %2[3]" :: "r" (from), "r" (from), "r" (dst));
     #endif
-    #if defined(__VX4A__)
+    #if defined(__VX4A__) || defined(__VX4B__)
     for(int i = 0; i < 8; i++) {
         ((uint32_t *)dst)[i] = from;
     }


### PR DESCRIPTION
Make sure VX4B can build the code without specify -D__VX4A__ in cmake